### PR TITLE
Update flow.js

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1393,6 +1393,7 @@
       this.xhr = new XMLHttpRequest();
       this.xhr.upload.addEventListener('progress', this.progressHandler, false);
       this.xhr.addEventListener("load", this.doneHandler, false);
+      this.xhr.addEventListener("loadend", this.doneHandler, false);
       this.xhr.addEventListener("error", this.doneHandler, false);
 
       var uploadMethod = evalOpts(this.flowObj.opts.uploadMethod, this.fileObj, this);


### PR DESCRIPTION
Added 'loadend' event listener to xhr.
Why is this needed?
Appears that in Firefox ver 109.0.1 xhr does not always fire event 'load'. But does fire 'loadend'. Problem was discovered while debugging old Angular 1 application. It is not reproducible in plain playground environment.